### PR TITLE
Solving Issue #18 when no epsilon is passed to a geometry defined with a kernel matrix

### DIFF
--- a/ott/geometry/geometry.py
+++ b/ott/geometry/geometry.py
@@ -105,8 +105,12 @@ class Geometry:
 
   @property
   def cost_matrix(self):
+    """Returns cost matrix, computes it if only kernel was specified."""
     if self._cost_matrix is None:
-      return -self.epsilon * jnp.log(self._kernel_matrix)
+      # If no epsilon was passed on to the geometry, then assume it is one by
+      # default.
+      cost = -jnp.log(self._kernel_matrix)
+      return cost if self._epsilon_init is None else self.epsilon * cost
     return self._cost_matrix
 
   @property


### PR DESCRIPTION
When defining a geometry using only a kernel, default to epsilon=1 by testing whether epsilon_init was None and avoid "autoepsilon" computations that would cause an infinite recursion.